### PR TITLE
show urls for swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # storcycle_api
 
-[Swagger Documentation](https://localhost/apidocs/)
+Swagger Documentation - https://localhost/apidocs
 
-[openapi.yaml](https://localhost/openapi.yaml)
+openapi.yaml - https://localhost/openapi.yaml
 
 ## StorCycle API Examples
 


### PR DESCRIPTION
want people to see urls for swagger docs in case they don't have storcycle installed locally